### PR TITLE
fix: preserve file permissions in buffered_write_to_file

### DIFF
--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -1,5 +1,7 @@
 import importlib
 import os
+import platform
+import stat
 import tempfile
 import threading
 import unittest
@@ -127,6 +129,28 @@ class TestCase(unittest.TestCase):
         save_file_pt(tensors, Path(filename))
         load_file_pt(Path(filename))
         os.remove(Path(filename))
+
+    @unittest.skipIf(
+        platform.system() == "Windows", "umask is not available on Windows"
+    )
+    def test_serialization_file_permissions(self):
+        # Regression test for #782: save_file writes through a tempfile +
+        # rename, which must not leak the tempfile's restrictive 0o600 mode
+        # onto the destination.
+        data = np.zeros((2, 2), dtype=np.int32)
+        filename = f"./out_permissions_{threading.get_ident()}.safetensors"
+        old_mask = os.umask(0o022)
+        try:
+            save_file({"test": data}, filename)
+            self.assertEqual(stat.S_IMODE(os.stat(filename).st_mode), 0o644)
+
+            # Overwriting keeps the permissions of the existing file.
+            os.chmod(filename, 0o640)
+            save_file({"test": data}, filename)
+            self.assertEqual(stat.S_IMODE(os.stat(filename).st_mode), 0o640)
+        finally:
+            os.umask(old_mask)
+            os.remove(filename)
 
     def test_pt_sf_save_model_overlapping_storage(self):
         m = torch.randn(10)

--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 hashbrown = { version = "0.16", features = ["serde"] }
 tempfile = { version = "3", optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -336,6 +336,28 @@ fn buffered_write_to_file<V: View>(
         f.flush()?;
     }
 
+    // `NamedTempFile` is always created with mode 0o600, which the rename
+    // below would otherwise hand over to `path` (#782). Restore the
+    // permissions a plain `File::create(path)` would have produced: the
+    // existing file's mode when overwriting, else 0o666 masked by the
+    // process umask.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let permissions = match std::fs::metadata(path) {
+            Ok(metadata) => metadata.permissions(),
+            Err(_) => {
+                // Reading the process umask requires setting it; restore it
+                // right away.
+                let umask = unsafe { libc::umask(0) };
+                unsafe { libc::umask(umask) };
+                std::fs::Permissions::from_mode(0o666 & !u32::from(umask))
+            }
+        };
+        temp.as_file().set_permissions(permissions)?;
+    }
+
     temp.persist(path).map_err(|e| e.error)?;
 
     Ok(())
@@ -1363,6 +1385,43 @@ mod tests {
         let raw = std::fs::read(&filename).unwrap();
         let reloaded = SafeTensors::deserialize(&raw).unwrap();
         assert_eq!(reloaded.tensor("w").unwrap().data(), bytes.as_slice());
+        std::fs::remove_file(&filename).unwrap();
+    }
+
+    #[cfg(all(feature = "std", unix))]
+    #[test]
+    fn test_serialize_to_file_permissions() {
+        // Regression test for #782: writing through a tempfile + rename (#764)
+        // left the destination with the tempfile's 0o600 mode instead of the
+        // umask-derived mode a plain `File::create` would have produced, so
+        // freshly saved models were no longer readable by other users.
+        use std::os::unix::fs::PermissionsExt;
+
+        let filename = std::env::temp_dir().join(format!(
+            "safetensors_test_782_{}_{:?}.safetensors",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_file(&filename);
+
+        let bytes: Vec<u8> = vec![0u8; 12];
+        let view = TensorView::new(Dtype::F32, vec![3], &bytes).unwrap();
+        let metadata: HashMap<String, TensorView> = [("w".to_string(), view)].into_iter().collect();
+
+        let old_mask = unsafe { libc::umask(0o022) };
+
+        // A new file gets the mode a plain `File::create` would have produced.
+        serialize_to_file(&metadata, None, &filename).unwrap();
+        let mode = std::fs::metadata(&filename).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o644);
+
+        // Overwriting keeps the permissions of the existing destination.
+        std::fs::set_permissions(&filename, std::fs::Permissions::from_mode(0o640)).unwrap();
+        serialize_to_file(&metadata, None, &filename).unwrap();
+        let mode = std::fs::metadata(&filename).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o640);
+
+        unsafe { libc::umask(old_mask) };
         std::fs::remove_file(&filename).unwrap();
     }
 


### PR DESCRIPTION
# What does this PR do?

Fixes #782.

Since #764, `serialize_to_file` creates a `tempfile::NamedTempFile` and renames
it into place. The tempfile crate always creates files with mode 0o600, and
`persist()` is just a rename, so the destination keeps 0o600 instead of the mode
a plain `File::create(path)` would have produced — 0o666 masked by the process
umask for a new file, or the existing file's mode when overwriting.

This restores both behaviors on unix before the `persist()` call: if the
destination already exists, its permission bits are copied onto the temp file;
otherwise the temp file gets `0o666 & !umask`, reading the umask with the usual
`umask(0)`-then-restore dance. The `libc` dependency is widened from macOS
(where it was already used for `F_NOCACHE`) to all unix targets. Windows is
unaffected.

Tested with a new unix-only unit test in `tensor.rs` (a fresh file is 0o644
under umask 022, and an existing file's 0o640 survives an overwrite) plus the
same checks through `save_file` in `bindings/python/tests/test_simple.py`. The
Rust test fails on unpatched `main` (mode 0o600), and the #762 mmap regression
test still passes.

## AI model use

We do accept PRs that were developed together with an AI model, but we ask
that you to fill out this section.

- [ ] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [x] Development of this PR was done by an AI model.

If you ticked one of the last two options, please state the model and model
version that you used:

Claude (Anthropic), via Claude Code.

If you ticked the last option, please list the prompt(s) that you used:

Investigate huggingface/safetensors issue #782 (files written by
`serialize_to_file` come out chmod 600 since the tempfile+rename change in
#764), find the root cause, and write a minimal fix that restores the prior
permission behavior (umask-derived mode for new files, preserved mode when
overwriting) with regression tests on both the Rust and Python sides.
