### PR TITLE
Make file preallocation best-effort in buffered_write_to_file

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -312,7 +312,8 @@ fn buffered_write_to_file<V: View>(
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let temp = tempfile::NamedTempFile::new_in(parent)?;
 
-    temp.as_file().set_len(total_size as u64)?;
+    // Best-effort preallocation: ignore failure on filesystems without ftruncate support (FUSE/HDFS/S3). The sequential writes below still produce a correct file; a genuine out-of-space error surfaces there.
+    let _ = temp.as_file().set_len(total_size as u64);
 
     // Serialize tensors to a file using direct I/O (bypassing page cache) using F_NOCACHE.
     // This yields ~30% performance improvement.

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -312,8 +312,14 @@ fn buffered_write_to_file<V: View>(
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let temp = tempfile::NamedTempFile::new_in(parent)?;
 
-    // Best-effort preallocation: ignore failure on filesystems without ftruncate support (FUSE/HDFS/S3). The sequential writes below still produce a correct file; a genuine out-of-space error surfaces there.
-    let _ = temp.as_file().set_len(total_size as u64);
+    // Preallocation is best-effort only when the filesystem reports it as unsupported
+    // (e.g. FUSE/HDFS/S3 ftruncate not implemented). The sequential writes below grow the
+    // file to total_size regardless; surface all other errors such as overflow, space, or IO.
+    if let Err(e) = temp.as_file().set_len(total_size as u64) {
+        if e.kind() != std::io::ErrorKind::Unsupported {
+            return Err(e.into());
+        }
+    }
 
     // Serialize tensors to a file using direct I/O (bypassing page cache) using F_NOCACHE.
     // This yields ~30% performance improvement.


### PR DESCRIPTION
# What does this PR do?

Fixes #787. `serialize_to_file` currently aborts on filesystems that don't support `ftruncate` (e.g. FUSE HDFS, some S3 mounts) because `buffered_write_to_file` propagates the `File::set_len` error. Preallocation is only an allocation hint — the sequential writes already grow the file to exactly `total_size` (the in-memory `serialize` path never preallocates) — so this makes `set_len` best-effort by ignoring its result, with a comment noting why.

Orthogonal to #793, which addresses a FUSE rename failure; this addresses the `ftruncate`/`set_len` preallocation path. Happy to coordinate if you'd prefer them consolidated.

## AI model use

- [ ] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [x] Development of this PR was done by an AI model.