### PR TITLE
Raise PermissionError instead of FileNotFoundError when safe_open lacks read access

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -7,7 +7,7 @@ mod metal;
 
 use core::slice;
 use memmap2::{Mmap, MmapOptions};
-use pyo3::exceptions::{PyException, PyFileNotFoundError};
+use pyo3::exceptions::{PyException, PyFileNotFoundError, PyIOError, PyPermissionError};
 use pyo3::prelude::*;
 use pyo3::sync::OnceLockExt;
 use pyo3::types::IntoPyDict;
@@ -665,11 +665,15 @@ impl Open {
         device: Option<Device>,
         backend: Backend,
     ) -> PyResult<Self> {
-        let file = File::open(&filename).map_err(|_| {
-            PyFileNotFoundError::new_err(format!(
+        let file = File::open(&filename).map_err(|e| match e.kind() {
+            std::io::ErrorKind::PermissionDenied => {
+                PyPermissionError::new_err(format!("Permission denied: {}", filename.display()))
+            }
+            std::io::ErrorKind::NotFound => PyFileNotFoundError::new_err(format!(
                 "No such file or directory: {}",
                 filename.display()
-            ))
+            )),
+            _ => PyIOError::new_err(format!("Unable to open {}: {e}", filename.display())),
         })?;
         let device = device.unwrap_or(Device::Cpu);
         if device != Device::Cpu

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -182,6 +182,22 @@ class ErrorsTestCase(unittest.TestCase):
                 pass
         self.assertEqual(str(ctx.exception), "No such file or directory: notafile")
 
+    @unittest.skipIf(
+        os.name == "nt" or not hasattr(os, "getuid") or os.getuid() == 0,
+        "requires POSIX file permissions and a non-root user",
+    )
+    def test_permission_denied(self):
+        with tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False) as f:
+            save_file_pt({"a": torch.zeros((2, 2))}, f.name)
+        try:
+            os.chmod(f.name, 0o000)
+            with self.assertRaises(PermissionError):
+                with safe_open(f.name, framework="pt"):
+                    pass
+        finally:
+            os.chmod(f.name, 0o600)
+            os.remove(f.name)
+
 
 class ReadmeTestCase(unittest.TestCase):
     def assertTensorEqual(self, tensors1, tensors2, equality_fn):


### PR DESCRIPTION
## Summary

`safe_open` mapped **every** `File::open` failure to `FileNotFoundError`, so a file that exists but is unreadable (EACCES) was reported as a misleading `No such file or directory` instead of `PermissionError`. These are distinct OS errors (ENOENT vs EACCES) with distinct Python exception types, and callers that branch on the exception type can't tell "missing" from "denied".

Reproduction (from #805):

```python
import os, tempfile, torch
from safetensors.torch import save_file
from safetensors import safe_open

path = os.path.join(tempfile.mkdtemp(), "m.safetensors")
save_file({"w": torch.tensor([1.0])}, path)
os.chmod(path, 0o000)
safe_open(path, framework="pt")   # was FileNotFoundError, now PermissionError
```

## Change

Match on `io::ErrorKind` in `Open::new`:
- `PermissionDenied` → `PermissionError`
- `NotFound` → `FileNotFoundError` (unchanged message)
- anything else → `OSError`, preserving the underlying error text

The existing `FileNotFoundError` path and message are untouched.

## Testing

Added `ErrorsTestCase.test_permission_denied` (skipped on Windows / when running as root). Verified against a freshly built wheel:

```
tests/test_simple.py::ErrorsTestCase::test_file_not_found PASSED
tests/test_simple.py::ErrorsTestCase::test_permission_denied PASSED
```

Closes #805
