### PR TITLE
fix(numpy): reject non-C-contiguous arrays

### DIFF
--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -13,6 +13,11 @@ def _flatten(
     flattened = {}
     for k, v in tensor_dict.items():
         tensor = v
+        if not tensor.flags.c_contiguous:
+            raise ValueError(
+                f"You are trying to save a non-C-contiguous tensor: `{k}` which is not allowed. "
+                "Please call `np.ascontiguousarray` on your tensor to pack it before saving."
+            )
         if not _is_little_endian(tensor):
             tensor = tensor.byteswap(inplace=False)
             keep_alive_buffer.append(tensor)
@@ -33,7 +38,7 @@ def save(
 
     Args:
         tensor_dict (`Dict[str, np.ndarray]`):
-            The incoming tensors. Tensors need to be contiguous and dense.
+            The incoming tensors. Tensors need to be C-contiguous and dense.
         metadata (`Dict[str, str]`, *optional*, defaults to `None`):
             Optional text only metadata you might want to save in your header.
             For instance it can be useful to specify more about the underlying
@@ -68,7 +73,7 @@ def save_file(
 
     Args:
         tensor_dict (`Dict[str, np.ndarray]`):
-            The incoming tensors. Tensors need to be contiguous and dense.
+            The incoming tensors. Tensors need to be C-contiguous and dense.
         filename (`str`, or `os.PathLike`)):
             The filename we're saving into.
         metadata (`Dict[str, str]`, *optional*, defaults to `None`):

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -193,7 +193,11 @@ class ReadmeTestCase(unittest.TestCase):
             self.assertTrue(equality_fn(v1, v2), f"{k} tensors are different")
 
     def test_numpy_example(self):
-        tensors = {"a": np.zeros((2, 2)), "b": np.zeros((2, 3), dtype=np.uint8)}
+        tensors = {
+            "a": np.arange(4, dtype=np.float32).reshape(2, 2),
+            "b": np.arange(6, dtype=np.uint8).reshape(2, 3),
+        }
+        self.assertTrue(all(tensor.flags.c_contiguous for tensor in tensors.values()))
 
         save_file(tensors, "./out_np.safetensors")
         out = save(tensors)
@@ -204,6 +208,28 @@ class ReadmeTestCase(unittest.TestCase):
 
         loaded = load(out)
         self.assertTensorEqual(tensors, loaded, np.allclose)
+
+    def test_numpy_rejects_non_c_contiguous_arrays(self):
+        tensors = {
+            "fortran": np.asfortranarray(np.arange(6, dtype=np.float32).reshape(2, 3)),
+            "strided": np.arange(12, dtype=np.float32).reshape(3, 4)[:, ::2],
+        }
+
+        for name, tensor in tensors.items():
+            with self.subTest(name=name):
+                self.assertFalse(tensor.flags.c_contiguous)
+                with self.assertRaisesRegex(
+                    ValueError, "C-contiguous.*ascontiguousarray"
+                ):
+                    save({"tensor": tensor})
+
+                with tempfile.TemporaryDirectory() as tmp:
+                    path = Path(tmp) / "tensor.safetensors"
+                    with self.assertRaisesRegex(
+                        ValueError, "C-contiguous.*ascontiguousarray"
+                    ):
+                        save_file({"tensor": tensor}, path)
+                    self.assertFalse(path.exists())
 
     def test_numpy_bool(self):
         tensors = {"a": np.asarray(False)}


### PR DESCRIPTION
Fixes #825

`safetensors.numpy.save` and `save_file` previously accepted Fortran-contiguous and strided arrays, but serialized their raw memory as C-order data. Loading could silently change the logical values.

This validates that NumPy inputs are C-contiguous before constructing their `TensorSpec` and raises a clear `ValueError` directing callers to `np.ascontiguousarray`. The public docstrings now state the C-contiguous requirement.

The regression coverage includes the original Fortran-contiguous case, a strided non-contiguous view, unchanged nonzero C-contiguous round trips through both APIs, and confirmation that `save_file` does not create output for rejected inputs.

Tests:
- `python -m pytest -q tests/test_simple.py` — 19 passed, 2 subtests passed
- `python -m pytest -q tests --ignore=tests/test_tf_comparison.py` — 67 passed, 30 skipped, 2 subtests passed; TensorFlow comparison omitted because TensorFlow was not installed
- `python -m ruff format --check .`
- `python -m ruff check .`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

## AI model use

- [ ] No AI model was used when making this PR.
- [x] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

Model: OpenAI GPT-5 (Codex)