### PR TITLE
fix(numpy): preserve non-C-contiguous array layout

### DIFF
--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -15,6 +15,9 @@ def _flatten(
         tensor = v
         if not _is_little_endian(tensor):
             tensor = tensor.byteswap(inplace=False)
+        if not tensor.flags.c_contiguous:
+            tensor = np.ascontiguousarray(tensor)
+        if tensor is not v:
             keep_alive_buffer.append(tensor)
         flattened[k] = TensorSpec(
             dtype=tensor.dtype.name,
@@ -33,7 +36,7 @@ def save(
 
     Args:
         tensor_dict (`Dict[str, np.ndarray]`):
-            The incoming tensors. Tensors need to be contiguous and dense.
+            The incoming tensors. Non-C-contiguous tensors are copied into C order before saving.
         metadata (`Dict[str, str]`, *optional*, defaults to `None`):
             Optional text only metadata you might want to save in your header.
             For instance it can be useful to specify more about the underlying
@@ -52,7 +55,7 @@ def save(
     byte_data = save(tensors)
     ```
     """
-    keep_alive_buffer = []  # to keep byteswapped tensors alive
+    keep_alive_buffer = []  # to keep converted tensors alive
     serialized = serialize(_flatten(tensor_dict, keep_alive_buffer), metadata=metadata)
     result = bytes(serialized)
     return result
@@ -68,7 +71,7 @@ def save_file(
 
     Args:
         tensor_dict (`Dict[str, np.ndarray]`):
-            The incoming tensors. Tensors need to be contiguous and dense.
+            The incoming tensors. Non-C-contiguous tensors are copied into C order before saving.
         filename (`str`, or `os.PathLike`)):
             The filename we're saving into.
         metadata (`Dict[str, str]`, *optional*, defaults to `None`):
@@ -89,7 +92,7 @@ def save_file(
     save_file(tensors, "model.safetensors")
     ```
     """
-    keep_alive_buffer = []  # to keep byteswapped tensors alive
+    keep_alive_buffer = []  # to keep converted tensors alive
     serialize_file(
         _flatten(tensor_dict, keep_alive_buffer), filename, metadata=metadata
     )

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -118,6 +118,25 @@ class TestCase(unittest.TestCase):
         self.assertEqual(out1[8:].index(b"\x00") + 8, 104)
         self.assertEqual((out1[8:].index(b"\x00") + 8) % 8, 0)
 
+    def test_serialization_preserves_non_c_contiguous_arrays(self):
+        arrays = {
+            "fortran": np.asfortranarray(np.arange(12, dtype=np.float32).reshape(3, 4)),
+            "strided": np.arange(30, dtype=np.int64).reshape(5, 6)[:, ::2],
+            "big_endian_fortran": np.asfortranarray(
+                np.arange(12, dtype=">i4").reshape(3, 4)
+            ),
+        }
+
+        from_bytes = load(save(arrays))
+        with tempfile.TemporaryDirectory() as directory:
+            filename = Path(directory) / "arrays.safetensors"
+            save_file(arrays, filename)
+            from_file = load_file(filename)
+
+        for name, expected in arrays.items():
+            np.testing.assert_array_equal(from_bytes[name], expected)
+            np.testing.assert_array_equal(from_file[name], expected)
+
     def test_accept_path(self):
         tensors = {
             "a": torch.zeros((2, 2)),


### PR DESCRIPTION
## Summary

Fixes #825.

The NumPy serializer passes an array's raw data pointer to the Rust serializer, whose tensor shape is interpreted in C order. Fortran-contiguous and strided arrays therefore wrote their physical memory order while retaining their logical shape, producing silently reordered values after loading.

This change converts only non-C-contiguous NumPy inputs to C order before constructing `TensorSpec` and keeps the converted arrays alive through serialization. C-contiguous inputs retain the existing zero-copy path. The `save` and `save_file` documentation now states the copy behavior.

The regression test covers Fortran-contiguous, strided, and big-endian Fortran arrays through both in-memory and file round trips.

## Validation

- NumPy 2.5: 71 passed, 10 skipped across the available Python framework tests
- NumPy 1.26: 24 passed, 1 skipped across the NumPy-focused tests
- `cargo test --manifest-path safetensors/Cargo.toml --all-features` (36 unit tests and 4 doc tests passed)
- `ruff format --check` on both changed Python files
- Issue reproducer with a `1000 x 32` Fortran array on NumPy 1.26 (`array_equal == True`)