### PR TITLE
Fix big-endian data in threadable serialization test

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -105,9 +105,12 @@ class TensorSpec:
     transparently doubles the last dimension so `spec.shape` always reflects
     the logical element count.
 
-    SAFETY: `data_ptr` is a raw memory address. The caller must ensure the
-    underlying buffer stays alive for the duration of every `serialize` /
-    `serialize_file` call that consumes this spec.
+    SAFETY: `data_ptr` is a raw memory address. It must reference a contiguous
+    buffer encoded in the safetensors format's little-endian byte order. This
+    type borrows the raw bytes and does not own, copy, byteswap, or otherwise
+    transform them. The caller must ensure the underlying buffer stays alive
+    for the duration of every `serialize` / `serialize_file` call that consumes
+    this spec.
     """
     def __init__(
         self,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -51,9 +51,12 @@ static TORCH_MPS_DLPACK: OnceLock<bool> = OnceLock::new();
 /// transparently doubles the last dimension so `spec.shape` always reflects
 /// the logical element count.
 ///
-/// SAFETY: `data_ptr` is a raw memory address. The caller must ensure the
-/// underlying buffer stays alive for the duration of every `serialize` /
-/// `serialize_file` call that consumes this spec.
+/// SAFETY: `data_ptr` is a raw memory address. It must reference a contiguous
+/// buffer encoded in the safetensors format's little-endian byte order. This
+/// type borrows the raw bytes and does not own, copy, byteswap, or otherwise
+/// transform them. The caller must ensure the underlying buffer stays alive
+/// for the duration of every `serialize` / `serialize_file` call that consumes
+/// this spec.
 #[pyclass(frozen, from_py_object)]
 #[derive(Clone, Debug)]
 struct TensorSpec {

--- a/bindings/python/tests/test_threadable.py
+++ b/bindings/python/tests/test_threadable.py
@@ -1,11 +1,14 @@
+import os
+import sys
+import threading
+import time
 import unittest
 from concurrent import futures
-import threading
+
 import numpy as np
-from safetensors import TensorSpec, serialize_file
 from safetensors.numpy import load_file
-import time
-import os
+
+from safetensors import TensorSpec, serialize_file
 
 
 class TestCase(unittest.TestCase):
@@ -16,13 +19,18 @@ class TestCase(unittest.TestCase):
         tensor_a = np.random.randn(2000, 20000).astype(np.float32)
         tensor_b = np.random.randint(0, 128, (20000, 2000), dtype=np.int8)
 
+        # TensorSpec consumes raw bytes in the format's little-endian order.
+        tensor_a_storage = (
+            tensor_a if sys.byteorder == "little" else tensor_a.byteswap(inplace=False)
+        )
+
         # Build the tensor dict with data pointers (as serialize_file expects)
         tensor_data = {
             "tensor_a": TensorSpec(
                 dtype=tensor_a.dtype.name,
                 shape=tensor_a.shape,
-                data_ptr=tensor_a.ctypes.data,
-                data_len=tensor_a.nbytes,
+                data_ptr=tensor_a_storage.ctypes.data,
+                data_len=tensor_a_storage.nbytes,
             ),
             "tensor_b": TensorSpec(
                 dtype=tensor_b.dtype.name,


### PR DESCRIPTION
# What does this PR do?

Fixes #812.

`test_serialize_file_releases_gil` passed a native-endian NumPy `float32`
buffer directly to the low-level `TensorSpec` API. On s390x, those raw bytes
are big-endian, while the safetensors format stores tensor payloads in
little-endian order. The serializer therefore wrote the supplied bytes as-is,
and `load_file` interpreted them as little-endian values. The `int8` tensor was
unaffected because byte order does not apply to single-byte values.

This change:

- keeps a little-endian storage buffer alive for the raw `TensorSpec` pointer
  when the test runs on a big-endian host;
- leaves the existing path unchanged on little-endian hosts; and
- documents in both the Rust API and Python stub that `TensorSpec` borrows a
  contiguous little-endian buffer and does not copy or byteswap it.

The high-level NumPy API already performs the equivalent byteswap before
serialization. This PR preserves the zero-copy behavior and scope of the
low-level API instead of adding an implicit allocation there.

## Validation

- Reproduced the original failure in a real `linux/s390x` QEMU container using
  Python 3.13: `tests/test_threadable.py` failed on the `float32` comparison.
- Re-ran the same test after the patch: `1 passed in 36.82s`.
- Ran `cargo test --lib` for the Python Rust extension in the same s390x
  container: `1 passed`.
- Ran `cargo fmt --manifest-path bindings/python/Cargo.toml -- --check`.
- Ran `ruff format --check` on the modified Python and stub files.
- Ran `git diff --check`.

The local minimal s390x image does not include PyTorch, so it could not collect
`tests/test_simple.py`; the repository's existing s390x CI image covers those
PyTorch-dependent tests.

## AI model use

- [ ] No AI model was used when making this PR.
- [x] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

Model: OpenAI Codex (the client did not expose a more specific model version).

