### PR TITLE
Fix PyTorch lazy conjugate and negative view serialization

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -569,6 +569,9 @@ def _flatten_as_ptr(
     _evaluate_tensors_for_save(tensors)
     flattened = {}
     for k, v in tensors.items():
+        # Conjugate and negative view bits change a tensor's logical values without
+        # changing its storage. Materialize them before reading from data_ptr().
+        v = v.resolve_conj().resolve_neg()
         # XXX: doing this check later on instead of in _evaluate_tensors_for_save
         # since on old versions of torch, SparseTensorImpl do not implement is_contiguous
         # and we do the sparsity check in _evaluate_tensors_for_save.

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -11,7 +11,9 @@ import torch
 from safetensors import SafetensorError, TensorSpec, safe_open, serialize
 from safetensors.numpy import load, load_file, save, save_file
 from safetensors.torch import _find_shared_tensors
+from safetensors.torch import load as load_pt
 from safetensors.torch import load_file as load_file_pt
+from safetensors.torch import save as save_pt
 from safetensors.torch import save_file as save_file_pt
 from safetensors.torch import storage_ptr, storage_size
 
@@ -127,6 +129,25 @@ class TestCase(unittest.TestCase):
         save_file_pt(tensors, Path(filename))
         load_file_pt(Path(filename))
         os.remove(Path(filename))
+
+    def test_pytorch_lazy_view_bits_roundtrip(self):
+        tensors = {
+            "conjugate": torch.tensor([1 + 2j, 3 + 4j], dtype=torch.complex64).conj(),
+            "negative": torch._neg_view(torch.tensor([1.0, 3.0])),
+        }
+
+        for name, tensor in tensors.items():
+            with self.subTest(name=name, destination="bytes"):
+                loaded = load_pt(save_pt({name: tensor}))[name]
+                torch.testing.assert_close(loaded, tensor)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filename = os.path.join(tmpdir, "lazy-view-bits.safetensors")
+            save_file_pt(tensors, filename)
+            loaded = load_file_pt(filename)
+            for name, tensor in tensors.items():
+                with self.subTest(name=name, destination="file"):
+                    torch.testing.assert_close(loaded[name], tensor)
 
     def test_pt_sf_save_model_overlapping_storage(self):
         m = torch.randn(10)


### PR DESCRIPTION
# What does this PR do?

PyTorch can represent conjugation and negation as lazy view bits: the tensor's logical values change while its underlying storage does not. These views remain contiguous, so the current serializer accepts them and reads directly from `data_ptr()`, writing the physical storage values instead of the tensor values.

For example, a logical `[1-2j, 3-4j]` conjugate view currently loads back as `[1+2j, 3+4j]` after a successful save. Negative views have the same failure mode.

This materializes both lazy bits immediately before the raw-pointer conversion. `resolve_conj()` and `resolve_neg()` return the original tensor when their respective bit is unset, so ordinary tensors retain the same zero-copy path. The resolved tensor is already kept alive by the existing `(array, tensor_ref)` buffer.

The regression test covers conjugate and negative views through both the in-memory `save`/`load` path and the file `save_file`/`load_file` path.

Fixes #831.

## Validation

- Confirmed on pristine current `main` (`6eb4dc9`) and safetensors 0.8.0 that both round trips compare unequal before the fix.
- `tests/test_simple.py` + `tests/test_pt_model.py`: **32 passed**.
- CPU portion of `tests/test_pt_comparison.py`: **21 passed, 7 skipped, 5 GPU tests deselected**.
- `ruff check` and `ruff format --check` on both modified files: passed.
- `git diff --check`: passed.

All tests used Python 3.13.3 and PyTorch 2.11 on CPU with numeric-library thread counts capped at one. GPU coverage is left to the repository CI matrix.

Immediately before opening this PR I re-fetched `main` and searched all current open PR titles, bodies, branches, and changed paths for conjugation, negative/lazy view bits, and the relevant PyTorch APIs. No competing fix exists.

## AI model use

- [ ] No AI model was used when making this PR.
- [x] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

Model: OpenAI Codex. It assisted with repository auditing, reproduction minimization, duplicate searches, implementation, and test execution. I reviewed the complete two-file diff and the validation results.
