### PR TITLE
Document `backend` in `safe_open`'s runtime docstring

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1376,6 +1376,13 @@ impl Open {
 ///
 ///     device (`str`, defaults to `"cpu"`):
 ///         The device on which you want the tensors.
+///
+///     backend (`str`, *keyword-only*, defaults to `"mmap"`):
+///         Storage backend used to serve tensor bytes. `"mmap"` (the default)
+///         memory-maps the file; `"pread"` reads tensor bytes with `pread(2)`.
+///         On Apple-silicon MPS, prefer `"pread"`: it reads straight into the
+///         shared `MTLBuffer` (1x model memory, no page-cache duplication) and
+///         loads a full model several times faster than `"mmap"`.
 #[pyclass]
 #[allow(non_camel_case_types)]
 struct safe_open {


### PR DESCRIPTION
The `.pyi` stub documents the `backend` keyword (`"mmap"` / `"pread"`), so IDE hovers show it — but the runtime docstring generated from `bindings/python/src/lib.rs` still stops at `device`, so `help(safetensors.safe_open)` and `safe_open.__doc__` never mention the argument. This copies the stub's own `Args` entry into the Rust doc comment, verbatim, so the two stay in step.

What `help(safetensors.safe_open)` shows today:

    Args:
        filename (`str`, or `os.PathLike`): ...
        framework (`str`): ...
        device (`str`, defaults to `"cpu"`): ...

After this PR it also carries the stub's `backend` entry — `"mmap"` (default), `"pread"`, and the Apple-silicon MPS note.

For what it's worth: we missed `backend="pread"` for a month during a slow-weight-loading investigation on ROCm precisely because `help()` did not show it — it turned out to be the lowest-resident-memory load path there ([context: open-questions §8](https://github.com/cadamcat/dual-radeon-vllm/blob/main/docs/open-questions.md#8-why-is-weight-loading-1948-slower-than-the-disk--two-effects-both-now-established)).