### PR TITLE
Fix NumPy Fortran-contiguous serialization

### DIFF
--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -13,8 +13,11 @@ def _flatten(
     flattened = {}
     for k, v in tensor_dict.items():
         tensor = v
+        if not tensor.flags.c_contiguous:
+            tensor = np.ascontiguousarray(tensor)
         if not _is_little_endian(tensor):
             tensor = tensor.byteswap(inplace=False)
+        if tensor is not v:
             keep_alive_buffer.append(tensor)
         flattened[k] = TensorSpec(
             dtype=tensor.dtype.name,
@@ -52,7 +55,7 @@ def save(
     byte_data = save(tensors)
     ```
     """
-    keep_alive_buffer = []  # to keep byteswapped tensors alive
+    keep_alive_buffer = []  # to keep converted tensors alive
     serialized = serialize(_flatten(tensor_dict, keep_alive_buffer), metadata=metadata)
     result = bytes(serialized)
     return result
@@ -89,7 +92,7 @@ def save_file(
     save_file(tensors, "model.safetensors")
     ```
     """
-    keep_alive_buffer = []  # to keep byteswapped tensors alive
+    keep_alive_buffer = []  # to keep converted tensors alive
     serialize_file(
         _flatten(tensor_dict, keep_alive_buffer), filename, metadata=metadata
     )

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -218,6 +218,19 @@ class ReadmeTestCase(unittest.TestCase):
         loaded = load(out)
         self.assertTensorEqual(tensors, loaded, np.allclose)
 
+    def test_numpy_fortran_contiguous_roundtrip(self):
+        tensor = np.asfortranarray(np.arange(24, dtype=np.float32).reshape((2, 3, 4)))
+        self.assertFalse(tensor.flags.c_contiguous)
+        self.assertTrue(tensor.flags.f_contiguous)
+
+        loaded = load(save({"tensor": tensor}))["tensor"]
+        np.testing.assert_array_equal(loaded, tensor)
+
+        with tempfile.NamedTemporaryFile(suffix=".safetensors") as f:
+            save_file({"tensor": tensor}, f.name)
+            loaded = load_file(f.name)["tensor"]
+        np.testing.assert_array_equal(loaded, tensor)
+
     def test_torch_example(self):
         tensors = {
             "a": torch.randn((2, 2)),


### PR DESCRIPTION
# What does this PR do?

The pointer-backed NumPy serialization path introduced in 0.8 reads an array's physical memory directly. For F-contiguous or otherwise strided arrays, those bytes are not in the C order encoded by the safetensors shape, so a successful round trip silently changes values.

This change materializes only non-C-contiguous arrays with `np.ascontiguousarray()` before constructing their `TensorSpec`. Already C-contiguous arrays keep the zero-copy pointer path. Converted arrays remain alive until serialization completes, just like existing endian-converted buffers.

Regression coverage verifies both in-memory `save`/`load` and file-backed `save_file`/`load_file` round trips for a genuinely F-contiguous 3D array.

Fixes #825.

## Testing

- `bindings/python/.venv/bin/python -m pytest -q bindings/python/tests/test_simple.py bindings/python/tests/test_multithreaded.py bindings/python/tests/test_threadable.py` — **22 passed**
- repository-pinned `ruff-check` pre-commit hooks on both changed files — passed
- repository-pinned `ruff-format` pre-commit hooks on both changed files — passed
- `git diff --check` — passed

## AI model use

- [ ] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [x] Development of this PR was done by an AI model.

Model: OpenAI Codex (the runtime did not expose a more specific model version to the agent).

Prompts/directives used:

- “Continuously identify tractable issues in leading open-source AI, AI-infrastructure, and agent projects; implement high-quality fixes in parallel, validate them, and submit useful upstream contributions.”
- Investigate safetensors issue #825, verify repository policy and duplicate work, reproduce the regression on current `main`, implement a focused compatibility fix with regression coverage, run the relevant tests and lint hooks, and submit the contribution with accurate AI disclosure.
