### PR TITLE
Resolve lazy tensor views before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This is my very personal and probably biased view:
   moment.
 - Order: 'C' or row-major. This seems to have won. We can add that information later if needed.
 - Stride: No striding, all tensors need to be packed before being serialized. I have yet to see a case where it seems useful to have a strided tensor stored in serialized format.
- - Sub 1 bytes dtypes: Dtypes can now have lower than 1 byte size, this makes alignment&adressing tricky. For now, the library will simply error out whenever an operation triggers an non aligned read. Trickier API may be created later for those non standard ops. 
+ - Sub 1 bytes dtypes: Dtypes can now have lower than 1 byte size, this makes alignment&addressing tricky. For now, the library will simply error out whenever an operation triggers an non aligned read. Trickier API may be created later for those non standard ops.
 
 ### Benefits
 

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -569,6 +569,8 @@ def _flatten_as_ptr(
     _evaluate_tensors_for_save(tensors)
     flattened = {}
     for k, v in tensors.items():
+        if v.is_conj() or v.is_neg():
+            v = v.resolve_conj().resolve_neg()
         # XXX: doing this check later on instead of in _evaluate_tensors_for_save
         # since on old versions of torch, SparseTensorImpl do not implement is_contiguous
         # and we do the sparsity check in _evaluate_tensors_for_save.

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -101,6 +101,15 @@ class TorchTestCase(unittest.TestCase):
             b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\xbf\x00\x00\x80?",
         )
 
+    def test_lazy_views(self):
+        tensors = {
+            "conj": torch.tensor([1 + 2j, 3 + 4j], dtype=torch.complex64).conj(),
+            "neg": torch._neg_view(torch.tensor([1.0, 3.0])),
+        }
+        loaded = load(save(tensors))
+        for name, tensor in tensors.items():
+            self.assertTrue(torch.equal(tensor, loaded[name]))
+
     def test_odd_dtype_fp8_e4m3fn(self):
         if not hasattr(torch, "float8_e4m3fn"):
             return  # torch.float8_e4m3fn requires 2.1


### PR DESCRIPTION
Resolve PyTorch conjugate and negative view bits before serializing tensor storage so logical values round-trip correctly.

Test: python3 -m py_compile bindings/python/py_src/safetensors/torch.py bindings/python/tests/test_pt_comparison.py

AI assistance was used.