### PR TITLE
Fix 32-bit tensor size validation overflow

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -645,16 +645,15 @@ impl Metadata {
                 .copied()
                 .try_fold(1usize, usize::checked_mul)
                 .ok_or(SafeTensorError::ValidationOverflow)?;
-            let nbits = nelements
-                .checked_mul(info.dtype.bitsize())
+            let nbits = (nelements as u128)
+                .checked_mul(info.dtype.bitsize() as u128)
                 .ok_or(SafeTensorError::ValidationOverflow)?;
 
             if nbits % 8 != 0 {
                 return Err(SafeTensorError::MisalignedSlice);
             }
-            let size = nbits
-                .checked_div(8)
-                .ok_or(SafeTensorError::ValidationOverflow)?;
+            let size =
+                usize::try_from(nbits / 8).map_err(|_| SafeTensorError::ValidationOverflow)?;
 
             if e - s != size {
                 return Err(SafeTensorError::TensorInvalidInfo);
@@ -1591,6 +1590,31 @@ mod tests {
             }
             _ => panic!("This should not be able to be deserialized"),
         }
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn test_large_tensor_with_addressable_byte_size() {
+        const ELEMENTS: usize = 196_761_600;
+        const BYTES: usize = 787_046_400;
+
+        assert!(ELEMENTS.checked_mul(Dtype::F32.bitsize()).is_none());
+        assert_eq!(ELEMENTS * 4, BYTES);
+
+        let metadata = Metadata::new(
+            None,
+            vec![(
+                "test".to_string(),
+                TensorInfo {
+                    dtype: Dtype::F32,
+                    shape: vec![ELEMENTS],
+                    data_offsets: (0, BYTES),
+                },
+            )],
+        )
+        .unwrap();
+
+        assert_eq!(metadata.data_len(), BYTES);
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

Fixes #817.

Metadata validation currently multiplies the element count by the dtype bit width in `usize`, then divides by eight. On a 32-bit target that intermediate can overflow even when the final byte span is addressable; for example, 196,761,600 F32 elements need 787,046,400 bytes but exceed `u32::MAX` when first represented as bits.

This change:

- keeps the existing checked `usize` shape-product validation;
- performs the bit-count intermediate with checked `u128` arithmetic;
- preserves the byte-alignment check required by packed F4/F6 dtypes; and
- converts only the final byte count back to `usize`, so genuine target-addressability overflow is still rejected.

The regression constructs metadata only, so it proves the 32-bit boundary without allocating the approximately 787 MB payload.

Validation performed:

- current `main` in an actual i686 Rust container: the new focused regression fails with `ValidationOverflow`;
- patched i686 build: focused regression passes;
- patched native 64-bit core tests: 36 unit tests and 4 doc tests pass;
- patched native 64-bit `--no-default-features`: 35 unit tests and 4 doc tests pass;
- `cargo clippy --all-targets -- -D warnings` passes;
- `rustfmt --check src/tensor.rs` passes.

The complete i686 suite has three unrelated existing failures (`test_gpt2`, `test_json_attack`, and `test_validation_overflow`): patched result is 34 passed / 3 failed, while the upstream control plus the new red regression is 33 passed / 4 failed. The only changed outcome is the targeted regression.

## AI model use

- [ ] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [x] Development of this PR was done by an AI model.

Model and version: GPT-5.6 Sol.

Prompts used:

- "Investigate and fix safetensors #817. Preserve packed sub-byte dtype semantics, add a deterministic 32-bit regression, and verify the change on an actual 32-bit target."
- "Review the integer arithmetic as untrusted-input parsing. Check overflow rejection, F4/F6 alignment, test sufficiency, and repository contribution requirements."
