### PR TITLE
Preserve safe_open permission errors

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -22,6 +22,7 @@ use safetensors::View;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::ErrorKind;
 use std::num::NonZeroUsize;
 use std::ops::Bound;
 use std::path::PathBuf;
@@ -665,11 +666,15 @@ impl Open {
         device: Option<Device>,
         backend: Backend,
     ) -> PyResult<Self> {
-        let file = File::open(&filename).map_err(|_| {
-            PyFileNotFoundError::new_err(format!(
-                "No such file or directory: {}",
-                filename.display()
-            ))
+        let file = File::open(&filename).map_err(|error| {
+            if error.kind() == ErrorKind::NotFound {
+                PyFileNotFoundError::new_err(format!(
+                    "No such file or directory: {}",
+                    filename.display()
+                ))
+            } else {
+                PyErr::from(error)
+            }
         })?;
         let device = device.unwrap_or(Device::Cpu);
         if device != Device::Cpu

--- a/bindings/python/tests/test_errors.py
+++ b/bindings/python/tests/test_errors.py
@@ -1,0 +1,31 @@
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+from safetensors.numpy import save_file
+
+from safetensors import safe_open
+
+
+class ErrorsTestCase(unittest.TestCase):
+    @unittest.skipIf(
+        os.name == "nt" or getattr(os, "geteuid", lambda: 0)() == 0,
+        "POSIX file permissions require a non-root user",
+    )
+    def test_permission_denied(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "model.safetensors"
+            save_file({"test": np.zeros(1, dtype=np.float32)}, path)
+            original_mode = stat.S_IMODE(path.stat().st_mode)
+            path.chmod(0)
+            try:
+                with (
+                    self.assertRaises(PermissionError),
+                    safe_open(path, framework="np"),
+                ):
+                    pass
+            finally:
+                path.chmod(original_mode)


### PR DESCRIPTION
# What does this PR do?

Fixes #805.

`safe_open` currently converts every `File::open` failure into the same custom `FileNotFoundError`, which hides real permission errors and other OS-level open failures.

This change keeps the exact historical exception and message for a genuinely missing file, while passing every other original `std::io::Error` through PyO3's native conversion. The later mmap and header-parsing paths are unchanged.

The regression creates a valid tensor file, removes its POSIX read permissions, and verifies the public `safe_open` API raises `PermissionError`. It skips Windows, where chmod does not model an ACL denial, and root, which can bypass discretionary access controls; the original mode is restored in `finally`.

Validation performed:

- pinned current main, non-root Linux: focused regression fails with `FileNotFoundError`;
- patched wheel, same non-root Linux test: 1 passed with `PermissionError`;
- existing exact missing-file behavior remains `FileNotFoundError: No such file or directory: notafile`;
- Python wheel build succeeds;
- `cargo fmt -- --check` succeeds for the Python binding crate;
- `cargo clippy --all-targets --all-features -- -D warnings` succeeds;
- Ruff format and lint succeed for the new test.

A direct `cargo test` invocation for the Python extension in the manylinux build image could not link a native static Python library, before test execution. The built-wheel public-API red/green test is the relevant local boundary proof; the repository's normal Python CI matrix remains the merge gate.

## AI model use

- [ ] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [x] Development of this PR was done by an AI model.

Models and versions: GPT-5.6 Sol for implementation and verification; GPT-5.6 Pro for an independent advisory review before submission.

Prompts used:

- "Investigate Safetensors #805 at the Rust/Python boundary. Reproduce it as a non-root user, preserve genuine NotFound compatibility, add a public-API regression, and verify the narrowest correct fix."
- "Adversarially review whether the candidate should preserve the exact NotFound branch and delegate every other File::open error to PyO3. Identify blockers, invariants, platform risks, and the minimum validation needed before submission."
