### PR TITLE
fix: reject slice start > stop instead of underflowing byte offsets

### DIFF
--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -372,6 +372,17 @@ class ReadmeTestCase(unittest.TestCase):
                 tensor = slice_[[0, 1]]
             self.assertEqual(str(cm.exception), "Non empty lists are not implemented")
 
+            # Regression test: a slice whose start is after its stop (both
+            # still within bounds) must be rejected cleanly rather than
+            # underflowing the byte-offset arithmetic.
+            with self.assertRaises(SafetensorError) as cm:
+                tensor = slice_[3:1]
+            self.assertEqual(
+                str(cm.exception),
+                "Error during slicing [3:1] with shape [10, 5]: "
+                "index 3 out of bounds for tensor dimension #0 of size 10",
+            )
+
             with self.assertRaises(SafetensorError) as cm:
                 tensor = slice_[2:, 20]
             self.assertEqual(

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -361,8 +361,12 @@ pub fn slice_byte_ranges(
                     (start, stop, step.get())
                 }
             };
-            if start >= dim || stop > dim {
-                let asked = if start >= dim {
+            if start >= dim || stop > dim || start > stop {
+                // `start > stop` (both otherwise in-bounds) falls through to
+                // the byte-offset arithmetic below unless caught here: the
+                // `step == 1` fast path computes `stop * span / 8 - offset`,
+                // which underflows `usize` instead of erroring.
+                let asked = if start >= dim || start > stop {
                     start
                 } else {
                     stop.saturating_sub(1)
@@ -759,6 +763,36 @@ mod tests {
                 ],
             ),
             Err(InvalidSlice::TooManySlices)
+        );
+    }
+
+    #[test]
+    fn test_start_after_stop() {
+        // Regression test: `start > stop` with *both* still `< dim` (so
+        // neither previously passed a `>= dim`/`> dim` check) used to fall
+        // through to the byte-offset arithmetic and underflow `usize`
+        // instead of being rejected up front.
+        let data: Vec<u8> = vec![0.0f32, 1.0, 2.0, 3.0, 4.0]
+            .into_iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+
+        let attn_0 = TensorView::new(Dtype::F32, vec![5], &data).unwrap();
+
+        assert_eq!(
+            SliceIterator::new(
+                &attn_0,
+                &[TensorIndexer::Narrow(
+                    Bound::Included(3),
+                    Bound::Excluded(1),
+                    NonZeroUsize::MIN,
+                )],
+            ),
+            Err(InvalidSlice::SliceOutOfRange {
+                asked: 3,
+                dim_index: 0,
+                dim_size: 5,
+            })
         );
     }
 }


### PR DESCRIPTION
# What does this PR do?

Fixes #843.

`slice_byte_ranges`'s bounds check only rejected `start >= dim` and `stop > dim`, so a `Narrow` slice bound with `start > stop` (both still `< dim`) fell through to the `step == 1` fast path's byte-offset arithmetic instead of being rejected. That arithmetic computes `stop * span / 8 - offset`, which underflows `usize` (silently wraps in a release build, since this crate sets no `overflow-checks` override) instead of erroring.

Reachable from Python via an ordinary slice against a well-formed file, e.g. `f.get_slice(name)[3:1]` — no crafted/malicious file needed. Before this fix it surfaces as an undocumented `SystemError: Negative size passed to PyByteArray_FromStringAndSize` instead of the library's own `SafetensorError`.

I checked every downstream consumer this underflow reaches (CPython's `PyByteArray_FromStringAndSize`, and the Metal buffer allocator on the macOS/MPS slicing path) — both already reject the resulting garbage size cleanly before touching memory, so this is a clean-error-message fix, not a memory-safety fix.

The fix adds `start > stop` to the existing bounds check in `slice_byte_ranges` (`safetensors/src/slice.rs`) so it's rejected via the same `InvalidSlice::SliceOutOfRange` path as the existing `start >= dim` / `stop > dim` cases.

## Testing

- Added `test_start_after_stop` to `safetensors/src/slice.rs`'s existing test module — `cargo test --all-features` passes (37/37).
- Added a regression case to `test_numpy_slice` in `bindings/python/tests/test_simple.py`, asserting the clean `SafetensorError` message — `pytest tests/test_simple.py` passes (18/18).
- `cargo clippy --locked --all-targets -- -D warnings` (the exact CI invocation) is clean.
- `ruff format --check` (the exact CI invocation) is clean.
- Kept the diff minimal — no unrelated formatting changes.

## AI model use

We do accept PRs that were developed together with an AI model, but we ask that you to fill out this section.

- [ ] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [x] Development of this PR was done by an AI model.

Model: Claude Sonnet 5 (`claude-sonnet-5`), via Claude Code. This bug was found during a broader security-focused code review of the header/metadata parser and Python binding boundary; the fix and tests above were written and verified by the model, and reviewed by me before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)